### PR TITLE
Add user-agent for `bors-ng`

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -43,6 +43,8 @@ self: super: {
 
     npmInstallFlags = "--prefix=assets --legacy-peer-deps";
 
+    patches = [ ./user-agent.patch ];
+
     preInstall =
       let
         phoenix = self.fetchFromGitHub {

--- a/user-agent.patch
+++ b/user-agent.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/github/oauth2/oauth2.ex b/lib/github/oauth2/oauth2.ex
+index d4db288..5092321 100644
+--- a/lib/github/oauth2/oauth2.ex
++++ b/lib/github/oauth2/oauth2.ex
+@@ -57,7 +57,7 @@ defmodule BorsNG.GitHub.OAuth2 do
+   @spec get_user!(t) :: BorsNG.GitHub.User.t()
+   def get_user!(client) do
+     client
+-    |> OAuth2.Client.get!("/user")
++    |> OAuth2.Client.get!("/user", [{"user-agent", "bors-ng"}])
+     |> Map.fetch!(:body)
+     |> BorsNG.GitHub.User.from_json!()
+   end


### PR DESCRIPTION
GitHub requires this, otherwise the oauth flow fails.